### PR TITLE
Fix subprocess crash

### DIFF
--- a/src/LinkRepoPanel.java
+++ b/src/LinkRepoPanel.java
@@ -10,6 +10,8 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
+import git.tools.client.GitSubprocessClient;
+
 public class LinkRepoPanel extends JPanel {
 	
 	private JLabel filePathInstructions;
@@ -23,16 +25,22 @@ public class LinkRepoPanel extends JPanel {
 		enterButton = new JButton("Save and Submit");
 		enterButton.addActionListener(new ActionListener() {
 			// on click, the button should writes the user's specified repo file path to a
-			// file
+			// file, or say that it failed on the main screen and write nothing
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				try {
+					GitSubprocessClient pathCheck = new GitSubprocessClient(fileField.getText());
+					pathCheck.runGitCommand("status");
 					PrintWriter output = new PrintWriter(new FileOutputStream("repo.txt", true));
 					output.println(fileField.getText());
 					output.close();
+					mainWindow.setLinkFailLabel(false);
 				} catch (FileNotFoundException ex) {
 					System.out.println(
 							"An error occurred, exiting program. Please manually add your repo to a file named \"repo.txt\" in the correct folder.");
+				} catch (RuntimeException exc) {
+					// bad path, so nothing gets written
+					mainWindow.setLinkFailLabel(true);
 				}
 				linkRepoWindow.setVisibility(false);
 			}

--- a/src/MainPanel.java
+++ b/src/MainPanel.java
@@ -25,8 +25,8 @@ public class MainPanel extends JPanel {
 
 	// these components can change during runtime, so they can't be declared in the
 	// constructor like the others
-	private JLabel selectedUser, pullLabel, titleLabel, pullRequestLabel, addCommitLabel;
-	private JPanel titlePanel, pullPanel, pullButtons, otherButtonsJPanel, pullRequestPanel, commitPanel, commitFieldsPanel, commitButtonsPanel;
+	private JLabel selectedUser, pullLabel, titleLabel, pullRequestLabel, addCommitLabel, linkFailLabel;
+	private JPanel titlePanel, pullPanel, pullButtons, otherButtonsJPanel, pullRequestPanel, commitPanel, commitFieldsPanel, commitButtonsPanel, otherPanel;
 	public JButton refreshButton, resolveButton, repoButton, themeButton, pullRequestRefreshButton, addButton, commitButton;
 	public JTextField commitPath, commitMessage;
 	private GitHubApiClient gitHubApiClient;
@@ -140,6 +140,10 @@ public class MainPanel extends JPanel {
 		this.add(pullRequestPanel);
 		
 		// other buttons
+		otherPanel = new JPanel(new GridLayout(2, 1));
+		linkFailLabel = new JLabel("", SwingConstants.CENTER);
+		linkFailLabel.setForeground(Color.red);
+		
 		otherButtonsJPanel = new JPanel();
 		repoButton = new JButton("Link a repo");
 		repoButton.addActionListener(new ActionListener() {
@@ -162,16 +166,26 @@ public class MainPanel extends JPanel {
 			}
 		});
 
-
+		otherPanel.add(linkFailLabel);
 		otherButtonsJPanel.add(repoButton);
 		otherButtonsJPanel.add(themeButton);
-		this.add(otherButtonsJPanel);
+		otherPanel.add(otherButtonsJPanel);
+		this.add(otherPanel);
 	}
 
 	// this updates all of the components that can be updated (the ones not declared
 	// in the constructor)
 	public void updateWindow() {
 		selectedUser.setText("Logged in as " + Driver.getUsername());
+	}
+	
+	public void setLinkFailLabel(boolean fail) {
+		if(fail) {
+			linkFailLabel.setText("The last repo you tried to link was not a valid Git repository.");
+		}
+		else {
+			linkFailLabel.setText("");
+		}
 	}
 
 	public void addChanges() {
@@ -214,6 +228,7 @@ public class MainPanel extends JPanel {
 			pullPanel.setBackground(Color.white);
 			pullButtons.setBackground(Color.white);
 			otherButtonsJPanel.setBackground(Color.white);
+			otherPanel.setBackground(Color.white);
 			pullRequestPanel.setBackground(Color.white);
 			selectedUser.setForeground(Color.darkGray);
 			titleLabel.setForeground(Color.darkGray);
@@ -253,6 +268,7 @@ public class MainPanel extends JPanel {
 			pullPanel.setBackground(Color.darkGray);
 			pullButtons.setBackground(Color.darkGray);
 			otherButtonsJPanel.setBackground(Color.darkGray);
+			otherPanel.setBackground(Color.darkGray);
 			pullRequestPanel.setBackground(Color.darkGray);
 			selectedUser.setForeground(Color.white);
 			titleLabel.setForeground(Color.white);

--- a/src/MainWindow.java
+++ b/src/MainWindow.java
@@ -44,4 +44,9 @@ public class MainWindow extends JFrame {
 		mainPanel.updateWindow();
 		this.setVisible(visibility);
 	}
+	
+	// updates the fail label if a repo was bad, this function is used in LinkRepoPanel
+	public void setLinkFailLabel(boolean fail) {
+		mainPanel.setLinkFailLabel(fail);
+	}
 }


### PR DESCRIPTION
Fixed an issue which caused the program to crash. If a bad filepath was given to the link window, it would write it to ```repo.txt``` anyways, and the program would crash later on if it tried to search for a repository at that bad filepath. The link window should now only accept valid Git environments when trying to link a repository.